### PR TITLE
Exclude histories

### DIFF
--- a/src/witan/cic/episodes/transformation_report.clj
+++ b/src/witan/cic/episodes/transformation_report.clj
@@ -38,7 +38,9 @@
              (map (fn [episode]
                     (let [fields ((juxt ::wce/id (fn [e] (str (::wce/dob e))) ::wce/sex ::wce/report-year (fn [e] (str (::wce/report-date e))) (fn [e] (str (::wce/ceased e))) ::wce/placement ::wce/legal-status ::wce/care-status ::wcie/file-name ::wcie/sheet-name ::wcie/row-index)
                                   episode)
-                          edit (first (::wce/edit episode))]
+                          edit (or
+                                (some #(when (= (::wce/command %) :remove) %) (::wce/edit episode))
+                                (first (::wce/edit episode)))]
                       (cond
                         (::wce/new edit)
                         (let [new (::wce/new edit)


### PR DESCRIPTION
If a the last episode of a history is open, but is not in the most recent report year, then that history is broken and should be marked as such for review, but excluded from the input scrubbed episodes.